### PR TITLE
Train - ÖBB: Add additional Postion properties

### DIFF
--- a/onboardapis/data.py
+++ b/onboardapis/data.py
@@ -12,7 +12,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from functools import wraps
 from types import MethodType
-from typing import Any, TypeVar, Generic, Callable, Tuple, Dict
+from typing import Any, TypeVar, Generic, Callable, Tuple, Dict, Optional
 
 from geopy.point import Point
 from geopy.distance import geodesic
@@ -94,9 +94,9 @@ class Position(object):
     """The latitude in decimal degrees"""
     longitude: float
     """The longitude in decimal degrees"""
-    altitude: float = None
+    altitude: Optional[float] = None
     """The altitude in meters"""
-    heading: float = None
+    heading: Optional[float] = None
     """The compass heading in degrees"""
 
     def __str__(self) -> str:

--- a/onboardapis/train/at/obb/apis.py
+++ b/onboardapis/train/at/obb/apis.py
@@ -26,4 +26,7 @@ class RailnetRegio(IncompleteTrainMixin, Train):
         return Position(
             latitude=self._data['gps']['JSON']['lat'],
             longitude=self._data['gps']['JSON']['lon'],
+            # these are only present in newer trains
+            altitude=self._data['gps']['JSON'].get('alt', None),
+            heading=self._data['gps']['JSON'].get('bearing', None),
         )


### PR DESCRIPTION
- In newer trains, the ÖBB trains have the `heading` (called `bearing` in their API) and `altitude` information present, so I added those, defaulting to `None` in older trains
- fixed `Position` member types